### PR TITLE
Create AWS Deployment Github Actions workflow 

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -1,17 +1,10 @@
 ---
     name: AWS Deployment
     
-    on: 
-      workflow_dispatch:
-        inputs:
-            environment:
-                description: "Environment to deploy to"
-                default: "staging"
-                options:
-                    - staging
-                    - production
-                required: true
-                type: choice
+    on:
+      push:
+        branches:
+          - main
            
     env:
       AWS_ACCOUNT_ID: ${{ vars.AWS_PUBLIC_DATA_RELEASES_ACCOUNT_ID }}
@@ -26,51 +19,43 @@
         contents: write  # Required for actions/checkout and OIDC tokens
     
     jobs:
-        build:
+        setup:
           runs-on: ubuntu-latest
     
           steps:
             - name: Checkout
               uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+
+              # Compute a short sha for use in the OIDC session name, which has a 64 character limit
+            - name: Add SHORT_SHA env property with commit short sha
+              run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
+    
+            - name: Configure AWS credentials with OIDC
+              uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+              with:
+                role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_simularium_ipub
+                role-session-name: binding-sim-edu-${{ env.SHORT_SHA }}
+                aws-region: ${{ env.AWS_REGION }} 
+
+        deploy-staging:
+            needs: setup
+            runs-on: ubuntu-latest
+
+            steps:      
+              - name: Copy build files to staging S3 bucket
+                run: aws s3 sync . ${{ env.STAGING_S3_BUCKET }}
+
+              - name: Invalidate CloudFront cache
+                run: aws cloudfront create-invalidation --distribution-id ${{ env.STAGING_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
         
-        deploy:
-            needs: build
+        deploy-production:
+            if: startsWith(github.ref, 'refs/tags/v')
+            needs: setup
             runs-on: ubuntu-latest
     
-            # Dynamically set the environment variable based on the input above:
-            environment: ${{ github.event.inputs.environment }}
-    
-            steps:
-    
-              # Compute a short sha for use in the OIDC session name, which has a 64 character limit
-              - name: Add SHORT_SHA env property with commit short sha
-                run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
-    
-              - name: Configure AWS credentials with OIDC
-                uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
-                with:
-                    role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_simularium_ipub
-                    role-session-name: binding-sim-edu-${{ env.SHORT_SHA }}
-                    aws-region: ${{ env.AWS_REGION }}
-    
-              # Setup variables based on the staging or production environment
-              - name: Set ECS variables based on environment
-                run: |
-                  if [ "${{ github.event.inputs.environment }}" == "production" ]; then
-                    echo "S3_BUCKET=${{ env.PRODUCTION_S3_BUCKET }}" >> $GITHUB_ENV
-                    echo "CLOUDFRONT_DISTRIBUTION_ID=${{ env.PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID }}" >> $GITHUB_ENV
-                  elif [ "${{ github.event.inputs.environment }}" == "staging" ]; then
-                    echo "S3_BUCKET=${{ env.STAGING_S3_BUCKET }}" >> $GITHUB_ENV
-                    echo "CLOUDFRONT_DISTRIBUTION_ID=${{ env.STAGING_CLOUDFRONT_DISTRIBUTION_ID }}" >> $GITHUB_ENV
-                  else
-                    echo "Invalid environment specified"
-                    exit 1
-                  fi          
-    
-              # Note that the command below will copy the files to the root of the S3 bucket e.g., s3://timelapse.allencell.org/ 
-              # If you want to copy files to a S3 prefix / subdirectory, you would want something like ${{ env.S3_BUCKET }}/your_prefix below      
+            steps:     
               - name: Copy build files to S3 root
-                run: aws s3 sync . ${{ env.S3_BUCKET }}
+                run: aws s3 sync . ${{ env.PRODUCTION_S3_BUCKET }}
     
               - name: Invalidate CloudFront cache
-                run: aws cloudfront create-invalidation --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+                run: aws cloudfront create-invalidation --distribution-id ${{ env.PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
Problem
=======
Estimated review size: medium


[#60596707](https://github.com/orgs/AllenCellSoftware/projects/5/views/2?pane=issue&itemId=60596707) - 
 GitHub Actions can publish releases to the [staging-ipub-simularium](https://us-west-2.console.aws.amazon.com/s3/buckets/staging-ipub-simularium?region=us-west-2&bucketType=general) and [production-ipub-simularium](https://us-west-2.console.aws.amazon.com/s3/buckets/production-ipub-simularium?region=us-west-2&bucketType=general) S3 buckets and invalidate the CloudFront cache and the contents of the S3 buckets will be served from https://staging.simularium.allencell.org/learn/binding-affinity/ and https://simularium.allencell.org/learn/binding-affinity/

Solution
========
Following a similar pattern to what is done by [`allen-cell-animated/nucmorp-colorizer`](https://github.com/allen-cell-animated/nucmorph-colorizer/blob/main/.github/workflows/aws-deploy.yml) I adapted the workflow per @meganrm [Slack request](https://allencellscience.slack.com/archives/C456TMPLG/p1713990668526259?thread_ts=1713984285.818789&cid=C456TMPLG) wherein it is clarified to publish the main branch to staging on merge, then publish to production when a tag is pushed. 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* Create AWS Deployment Github Actions workflow 

Steps to Verify:
----------------
1. After this PR is merged, and since the workflow is only triggered by pushes to the main branch, then we'll need to push a change to the main branch. 
2. Verify that the AWS Deployment Github Actions workflow runs successfully; if not, proceed with troubleshooting. 

