### PR TITLE
Move AWS credentials to the deploy jobs so the AWS CLI can find them and sync files to S3

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -26,6 +26,11 @@
             - name: Checkout
               uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
+        deploy-staging:
+            needs: setup
+            runs-on: ubuntu-latest
+
+            steps:      
               # Compute a short sha for use in the OIDC session name, which has a 64 character limit
             - name: Add SHORT_SHA env property with commit short sha
               run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
@@ -35,18 +40,13 @@
               with:
                 role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_simularium_ipub
                 role-session-name: binding-sim-edu-${{ env.SHORT_SHA }}
-                aws-region: ${{ env.AWS_REGION }} 
+                aws-region: ${{ env.AWS_REGION }}
 
-        deploy-staging:
-            needs: setup
-            runs-on: ubuntu-latest
+            - name: Copy build files to staging S3 bucket
+              run: aws s3 sync . ${{ env.STAGING_S3_BUCKET }}
 
-            steps:      
-              - name: Copy build files to staging S3 bucket
-                run: aws s3 sync . ${{ env.STAGING_S3_BUCKET }}
-
-              - name: Invalidate CloudFront cache
-                run: aws cloudfront create-invalidation --distribution-id ${{ env.STAGING_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+            - name: Invalidate CloudFront cache
+              run: aws cloudfront create-invalidation --distribution-id ${{ env.STAGING_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
         
         deploy-production:
             if: startsWith(github.ref, 'refs/tags/v')
@@ -54,8 +54,19 @@
             runs-on: ubuntu-latest
     
             steps:     
-              - name: Copy build files to S3 root
-                run: aws s3 sync . ${{ env.PRODUCTION_S3_BUCKET }}
+              # Compute a short sha for use in the OIDC session name, which has a 64 character limit
+            - name: Add SHORT_SHA env property with commit short sha
+              run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
     
-              - name: Invalidate CloudFront cache
-                run: aws cloudfront create-invalidation --distribution-id ${{ env.PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+            - name: Configure AWS credentials with OIDC
+              uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+              with:
+                role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_simularium_ipub
+                role-session-name: binding-sim-edu-${{ env.SHORT_SHA }}
+                aws-region: ${{ env.AWS_REGION }}
+
+            - name: Copy build files to S3 root
+              run: aws s3 sync . ${{ env.PRODUCTION_S3_BUCKET }}
+    
+            - name: Invalidate CloudFront cache
+              run: aws cloudfront create-invalidation --distribution-id ${{ env.PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
Problem
=======
Estimated review size: small


Fix a bug introduced in #68 wherein AWS credentials were not configured in the correct job and result in the AWS CLI failing to find any credentials, thereby resulting in a failing upload to the S3 buckets. You can see the `Run aws s3 sync . s3://staging-ipub-simularium
fatal error: Unable to locate credentials` failure [here](https://github.com/simularium/binding-sim-edu/actions/runs/8883035453/job/24389012984)

Solution
========
Move AWS credentials to the deploy jobs so the AWS CLI can find them and sync files to S3

with @meganrm 

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* Move AWS credentials to the deploy jobs so the AWS CLI can find them and sync files to S3

Steps to Verify:
----------------
After merge, I will verify that the Github Actions deployment workflow is successful. 

