### PR TITLE
 Separate CloudFront and S3 AWS Account IDs since the resources live in different AWS accounts

### DIFF
--- a/.github/workflows/aws-deploy.yml
+++ b/.github/workflows/aws-deploy.yml
@@ -41,9 +41,6 @@
                 role-to-assume: arn:aws:iam::${{ env.S3_AWS_ACCOUNT_ID }}:role/github_simularium_ipub
                 role-session-name: binding-sim-edu-${{ env.SHORT_SHA }}
                 aws-region: ${{ env.AWS_REGION }}
-
-            - name: Print debug messages
-              run: pwd && ls -al
             
             - name: Copy build files to staging S3 bucket
               run: aws s3 sync . ${{ env.STAGING_S3_BUCKET }}
@@ -78,7 +75,7 @@
                 aws-region: ${{ env.AWS_REGION }}
 
             - name: Copy build files to S3 root
-              run: aws s3 sync ../ ${{ env.PRODUCTION_S3_BUCKET }}
+              run: aws s3 sync . ${{ env.PRODUCTION_S3_BUCKET }}
 
             - name: Configure AWS credentials with OIDC for CloudFront cache invalidation
               uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502


### PR DESCRIPTION
Problem
=======
Estimated review size: small

Fixes Github Actions AWS Deployment by separating CloudFront and S3 AWS Account IDs since the resources live in different AWS accounts and require separate credentials. 

Solution
========
Fixes Github Actions AWS Deployment by separating CloudFront and S3 AWS Account IDs since the resources live in different AWS accounts and require separate credentials. 

with @meganrm 

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
*  Separate CloudFront and S3 AWS Account IDs since the resources live in different AWS accounts

Steps to Verify:
----------------
[This test run of the workflow was successful](https://github.com/simularium/binding-sim-edu/actions/runs/8885293057/job/24396332366) and https://staging.simularium.allencell.org/learn/binding-affinity/ appears to be serving the expected index.html file, although the file appears to be empty. 

https://staging.simularium.allencell.org/learn/binding-affinity/AUTHORS.md is another test serving from the same S3 bucket. 
