### PR TITLE
Fix/is equilibrium

### DIFF
--- a/src/simulation/BindingSimulator2D.ts
+++ b/src/simulation/BindingSimulator2D.ts
@@ -274,8 +274,8 @@ export default class BindingSimulator implements IClientSimulatorImpl {
             return;
         }
 
-        // checking the rightmost quadrant
-        // and the left most quadrant
+        // checking the rightmost third of the simulation
+        // and the left most third of the simulation
         if (agentInstance.pos.x < -this.size / 3) {
             this.numberAgentOnLeft++;
         } else if (agentInstance.pos.x > this.size / 3) {


### PR DESCRIPTION
Problem
=======
Estimated review size: small

the system would be in equilibrium but the `isMixed` value was still false

Solution
========
added a check to see if either agent had been used up 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

