### PR TITLE
fix png urls

### DIFF
--- a/src/components/FinalPage.tsx
+++ b/src/components/FinalPage.tsx
@@ -1,18 +1,20 @@
-import styles from "./finalpage.module.css";
 import { Flex } from "antd";
+import diagram1Url from "../assets/antibody-diagram-01.png";
+import diagram2Url from "../assets/antibody-diagram-02.png";
+import styles from "./finalpage.module.css";
 
 const FinalPage: React.FC = () => {
     return (
         <Flex className={styles.container}>
             <div className={styles.imageContainer}>
                 <img
-                    src="src/assets/antibody-diagram-01.png"
+                    src={diagram1Url}
                     alt="antibody bound to antigen with lower affinity"
                 />
             </div>
             <div className={styles.imageContainer}>
                 <img
-                    src="src/assets/antibody-diagram-02.png"
+                    src={diagram2Url}
                     alt="antibody bound to antigen with higher affinity"
                 />
             </div>

--- a/src/components/labview.module.css
+++ b/src/components/labview.module.css
@@ -1,6 +1,6 @@
 .container {
     position: absolute;
-    background-image: url("src/assets/ipub-bg_4.png");
+    background-image: url("../assets/ipub-bg_4.png");
     background-color: black;
     background-size: cover;
     background-repeat: no-repeat;


### PR DESCRIPTION
Problem
=======
Estimated review size: small

the assets weren't loading on the staging site

Solution
========
fixed the asset urls using vite import 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. bun dev
2. first image should still load (it did before as well) 
3. once we merge this, it should also load on staging (I've confirmed by looking at the build)

