### PR TITLE
center content text

### DIFF
--- a/src/components/main-layout/layout.module.css
+++ b/src/components/main-layout/layout.module.css
@@ -30,6 +30,7 @@
     flex-direction: column;
     gap: 10px;
     max-width: 982px;
+    margin: auto;
 }
 
 .side-panel {


### PR DESCRIPTION
Problem
=======
Estimated review size: x-small

In a design review, Lyndsay thought it would be better to center the text content while maintaining the max width 
closes #101 

Solution
========
auto margin 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Screenshots (optional):
-----------------------
<img width="1658" alt="Screenshot 2024-07-29 at 3 29 12 PM" src="https://github.com/user-attachments/assets/7057705b-cf7f-4bd8-a30a-0db9432753e5">
