### PR TITLE
overlay buttons should have transparency

### DIFF
--- a/src/components/shared/button-library.module.css
+++ b/src/components/shared/button-library.module.css
@@ -21,7 +21,7 @@
 
 .tertiary {
     composes: base-button;
-    background: #000000cc;
+    background-color: #000000cc;
     color: var(--primary-color);
     border-color: var(--primary-color);
 }


### PR DESCRIPTION
Problem
=======
Estimated review size: x-small
The overlay buttons are supposed to have a little transparency 
closes #98 

Solution
========
Use color from the design 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)



Screenshots (optional):
-----------------------

<img width="353" alt="Screenshot 2024-07-30 at 9 49 19 AM" src="https://github.com/user-attachments/assets/a0d4a313-e5aa-48c7-a6d9-270126abf5e3">

