### PR TITLE
move button over

### DIFF
--- a/src/components/ViewSwitch.tsx
+++ b/src/components/ViewSwitch.tsx
@@ -49,7 +49,7 @@ const ViewSwitch: React.FC<ViewSwitchProps> = ({ hasProgressed }) => {
 
     if (page === 1) {
         const siderWidth = window.innerWidth * 0.25;
-        buttonStyle = { ...buttonStyle, left: -siderWidth + 16 };
+        buttonStyle = { ...buttonStyle, left: -siderWidth + buttonStyle.left };
     }
 
     return (


### PR DESCRIPTION
Problem
=======
Estimated review size: x-small
initially the switch to sim view button should be over to the left


Solution
========
adjust the position 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Screenshots (optional):
-----------------------
before: 

<img width="1654" alt="Screenshot 2024-07-30 at 12 18 40 PM" src="https://github.com/user-attachments/assets/cff7a7ac-3a4e-4692-99fa-999b5589b7a6">

after:

<img width="1388" alt="Screenshot 2024-07-30 at 12 18 29 PM" src="https://github.com/user-attachments/assets/3b87e1b1-e216-421a-8742-ce6466559e7a">
