### PR TITLE
open definitions on hover as well as click, and underline them

### DIFF
--- a/src/components/shared/Definition.tsx
+++ b/src/components/shared/Definition.tsx
@@ -27,7 +27,12 @@ const Definition: React.FC<GlossaryTermProps> = ({ term, displayValue }) => {
         </>
     );
     return (
-        <Popover content={content} trigger="click" placement="bottom">
+        <Popover
+            content={content}
+            trigger={["click", "hover"]}
+            mouseEnterDelay={0.1}
+            placement="bottom"
+        >
             <a href="#!">{displayValue || term}</a>
         </Popover>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -76,6 +76,10 @@ a {
     color: var(--primary-color);
 }
 
+a:hover {
+    text-decoration: underline;
+}
+
 a:hover,
 a:focus,
 a:active {


### PR DESCRIPTION
Problem
=======
Estimated review size: small

#119 

Solution
========
people didn't always know words were clickable, so added hover as well 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
