### PR TITLE
add units and simplify text

### DIFF
--- a/src/components/quiz-questions/KdQuestion.tsx
+++ b/src/components/quiz-questions/KdQuestion.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
 import { valueType } from "antd/es/statistic/utils";
+import { Flex } from "antd";
 
 import QuizForm from "./QuizForm";
 import VisibilityControl from "../shared/VisibilityControl";
 import InputNumber from "../shared/InputNumber";
-import { kds } from "../../constants";
+import { MICRO, kds } from "../../constants";
 import { FormState } from "./types";
 import styles from "./popup.module.css";
 import { Module } from "../../types";
@@ -55,15 +56,16 @@ const KdQuestion: React.FC<KdQuestionProps> = ({ reactionType }) => {
         <div className={styles.inputFormContent}>
             <p>
                 Referencing the Equilibrium Concentration plot, what is the
-                binding affinity?
+                binding affinity? (K<sub>d</sub> = ?)
             </p>
-            <b>
-                K<sub>d</sub> = ?
-            </b>
-            <InputNumber
-                value={selectedAnswer || ""}
-                onChange={handleAnswerSelection}
-            />
+            <Flex gap={8} align="baseline" style={{ maxWidth: 230 }}>
+                <InputNumber
+                    value={selectedAnswer || ""}
+                    onChange={handleAnswerSelection}
+                    placeholder="Type approximate value..."
+                />
+                <span> {MICRO}M</span>
+            </Flex>
         </div>
     );
     return (

--- a/src/components/quiz-questions/KdQuestion.tsx
+++ b/src/components/quiz-questions/KdQuestion.tsx
@@ -54,12 +54,13 @@ const KdQuestion: React.FC<KdQuestionProps> = ({ reactionType }) => {
 
     const formContent = (
         <div className={styles.inputFormContent}>
-            <p>
+            <p id="kd question">
                 Referencing the Equilibrium Concentration plot, what is the
                 binding affinity? (K<sub>d</sub> = ?)
             </p>
             <Flex gap={8} align="baseline" style={{ maxWidth: 230 }}>
                 <InputNumber
+                    aria-labelledby="kd question"
                     value={selectedAnswer || ""}
                     onChange={handleAnswerSelection}
                     placeholder="Type approximate value..."

--- a/src/components/shared/InputNumber.tsx
+++ b/src/components/shared/InputNumber.tsx
@@ -2,13 +2,17 @@ import React from "react";
 import type { InputNumberProps } from "antd";
 import { InputNumber as InputNumberAntd } from "antd";
 
-const InputNumber: React.FC<InputNumberProps> = ({ value, onChange }) => (
+const InputNumber: React.FC<InputNumberProps> = ({
+    value,
+    onChange,
+    placeholder,
+}) => (
     <InputNumberAntd
         value={value}
         onChange={onChange}
         controls={false}
         step={0.1}
-        placeholder="Type your answer here..."
+        placeholder={placeholder || "Type your answer here..."}
     />
 );
 


### PR DESCRIPTION
Problem
=======
Estimated review size: small
addresses #119 (reference screen shot in the comment by @lynwilhelm ) 

Solution
========
The quiz question confused a few users, we adjusted to make it clear it's a estimate, and added units so they don't do that themselves 


with @lynwilhelm 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

design: 
<img width="389" alt="Screenshot 2024-09-30 at 5 08 30 PM" src="https://github.com/user-attachments/assets/7c8842e5-89ff-4332-8b5f-5f185346e7a3">

this branch: 
<img width="389" alt="Screenshot 2024-09-30 at 5 08 30 PM" src="https://github.com/user-attachments/assets/708e4010-ead2-44f6-b493-b3d8482e212b">
