### PR TITLE
Rework equilibrium data 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,10 +32,11 @@ import { ProductOverTimeTrace } from "./components/plots/types";
 import MainLayout from "./components/main-layout/Layout";
 import usePageNumber from "./hooks/usePageNumber";
 import fetch3DTrajectory from "./utils/fetch3DTrajectory";
-import { insertIntoArray, insertValueSorted } from "./utils";
+import { getColorIndex, insertValueSorted, updateArrayInState } from "./utils";
 import PreComputedPlotData from "./simulation/PreComputedPlotData";
 import PreComputedSimulationData from "./simulation/PreComputedSimulationData";
 import LiveSimulationData from "./simulation/LiveSimulationData";
+import { PLOT_COLORS } from "./components/plots/constants";
 
 const ADJUSTABLE_AGENT = AgentName.B;
 
@@ -90,6 +91,8 @@ function App() {
                 LiveSimulationData.INITIAL_CONCENTRATIONS[AgentName.B],
             [productName]: 0,
         });
+    const [recordedInputConcentration, setRecordedInputConcentration] =
+        useState<number[]>([]);
     const [productOverTimeTraces, setProductOverTimeTraces] = useState<
         ProductOverTimeTrace[]
     >([]);
@@ -99,8 +102,12 @@ function App() {
     const [unBindingEventsOverTime, setUnBindingEventsOverTime] = useState<
         number[]
     >([]);
-    const [inputEquilibriumConcentrations, setInputEquilibriumConcentrations] =
+    const [recordedReactantConcentrations, setRecordedReactantConcentration] =
         useState<number[]>([]);
+    const [timeToReachEquilibrium, setTimeToReachEquilibrium] = useState<
+        number[]
+    >([]);
+    const [dataColors, setDataColors] = useState<string[]>([]);
     const [
         productEquilibriumConcentrations,
         setProductEquilibriumConcentrations,
@@ -113,10 +120,19 @@ function App() {
         setCurrentProductConcentrationArray,
     ] = useState<number[]>([]);
 
-    const resetAnalysisState = () => {
+    const resetCurrentRunAnalysisState = () => {
         setBindingEventsOverTime([]);
         setUnBindingEventsOverTime([]);
         setCurrentProductConcentrationArray([]);
+    };
+
+    const clearAllAnalysisState = () => {
+        resetCurrentRunAnalysisState();
+        setRecordedInputConcentration([]);
+        setProductOverTimeTraces([]);
+        setRecordedReactantConcentration([]);
+        setTimeToReachEquilibrium([]);
+        setDataColors([]);
     };
 
     // SIMULATION INITIALIZATION
@@ -129,7 +145,7 @@ function App() {
         setInputConcentration(
             simulationData.getInitialConcentrations(activeAgents)
         );
-        resetAnalysisState();
+        resetCurrentRunAnalysisState();
         const trajectory =
             simulationData.createAgentsFromConcentrations(activeAgents);
         if (!trajectory) {
@@ -166,9 +182,7 @@ function App() {
             LiveSimulationData.INITIAL_CONCENTRATIONS[AgentName.B]
         );
         setIsPlaying(false);
-        resetAnalysisState();
-        setInputEquilibriumConcentrations([]);
-        setProductEquilibriumConcentrations([]);
+        clearAllAnalysisState();
     };
 
     useEffect(() => {
@@ -213,8 +227,8 @@ function App() {
     // Ongoing check to see if they've measured enough values to determine Kd
     const halfFilled = inputConcentration.A ? inputConcentration.A / 2 : 5;
     const uniqMeasuredConcentrations = useMemo(
-        () => uniq(inputEquilibriumConcentrations),
-        [inputEquilibriumConcentrations]
+        () => uniq(productEquilibriumConcentrations),
+        [productEquilibriumConcentrations]
     );
     const hasAValueAboveKd = useMemo(
         () =>
@@ -277,7 +291,8 @@ function App() {
         async () => {
             setIsPlaying(false);
             setTrajectoryStatus(TrajectoryStatus.LOADING);
-            resetAnalysisState();
+            totalReset();
+
             await fetch3DTrajectory(
                 PreComputedSimulationData.EXAMPLE_TRAJECTORY_URLS[
                     currentModule
@@ -412,7 +427,7 @@ function App() {
         const agentId = LiveSimulationData.AVAILABLE_AGENTS[agentName].id;
         clientSimulator.changeConcentration(agentId, value);
         simulariumController.gotoTime(time + 1);
-        resetAnalysisState();
+        resetCurrentRunAnalysisState();
     };
 
     const setEquilibriumFeedbackTimeout = (message: ReactNode | string) => {
@@ -426,25 +441,52 @@ function App() {
         if (!clientSimulator) {
             return false;
         }
-        const productConcentration =
-            clientSimulator.getCurrentConcentrations(productName)[productName];
-        const reactantConcentration = inputConcentration[ADJUSTABLE_AGENT] || 0;
 
         if (!clientSimulator.isMixed()) {
             setEquilibriumFeedbackTimeout("Not yet!");
             return false;
         }
+        const currentInputConcentration = inputConcentration[ADJUSTABLE_AGENT];
+        const productConcentration =
+            clientSimulator.getCurrentConcentrations(productName)[productName];
+        const reactantConcentration =
+            clientSimulator.getCurrentConcentrations(productName)[
+                ADJUSTABLE_AGENT
+            ];
+
+        const currentTime =
+            (bindingEventsOverTime.length * 10 * timeFactor) / 1000;
         const { newArray, index } = insertValueSorted(
-            inputEquilibriumConcentrations,
+            recordedReactantConcentrations,
             reactantConcentration
         );
-        setInputEquilibriumConcentrations(newArray as number[]);
-        const newProductArray = insertIntoArray(
+        setRecordedReactantConcentration(newArray as number[]);
+        updateArrayInState(
             productEquilibriumConcentrations,
             index,
-            productConcentration
+            productConcentration,
+            setProductEquilibriumConcentrations
         );
-        setProductEquilibriumConcentrations(newProductArray as number[]);
+        updateArrayInState(
+            recordedInputConcentration,
+            index,
+            currentInputConcentration ?? 0,
+            setRecordedInputConcentration
+        );
+        updateArrayInState(
+            timeToReachEquilibrium,
+            index,
+            currentTime,
+            setTimeToReachEquilibrium
+        );
+        const color =
+            PLOT_COLORS[
+                getColorIndex(
+                    currentInputConcentration ?? 0,
+                    simulationData.getMaxConcentration(currentModule)
+                )
+            ];
+        updateArrayInState(dataColors, index, color, setDataColors);
         setEquilibriumFeedbackTimeout(
             <>
                 Great! <CheckCircleOutlined />
@@ -476,7 +518,7 @@ function App() {
                         handleTrajectoryChange,
                         viewportSize,
                         setViewportSize,
-                        recordedConcentrations: inputEquilibriumConcentrations,
+                        recordedConcentrations: recordedInputConcentration,
                     }}
                 >
                     <MainLayout
@@ -531,11 +573,15 @@ function App() {
                                 currentAdjustableAgentConcentration={
                                     inputConcentration[ADJUSTABLE_AGENT] || 0
                                 }
-                                equilibriumConcentrations={{
+                                equilibriumData={{
                                     inputConcentrations:
-                                        inputEquilibriumConcentrations,
+                                        recordedInputConcentration,
+                                    reactantConcentrations:
+                                        recordedReactantConcentrations,
                                     productConcentrations:
                                         productEquilibriumConcentrations,
+                                    timeToEquilibrium: timeToReachEquilibrium,
+                                    colors: dataColors,
                                 }}
                                 equilibriumFeedback={equilibriumFeedback}
                             />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -561,7 +561,9 @@ function App() {
                             />
                         }
                         centerPanel={
-                            <CenterPanel reactionType={currentModule} />
+                            <CenterPanel
+                                kd={simulationData.getKd(currentModule)}
+                            />
                         }
                         rightPanel={
                             <RightPanel
@@ -587,6 +589,7 @@ function App() {
                                         productEquilibriumConcentrations,
                                     timeToEquilibrium: timeToReachEquilibrium,
                                     colors: dataColors,
+                                    kd: simulationData.getKd(currentModule),
                                 }}
                                 equilibriumFeedback={equilibriumFeedback}
                             />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -457,12 +457,10 @@ function App() {
         if (currentInputConcentration === undefined) {
             return false;
         }
-        const productConcentration =
-            clientSimulator.getCurrentConcentrations(productName)[productName];
-        const reactantConcentration =
-            clientSimulator.getCurrentConcentrations(productName)[
-                ADJUSTABLE_AGENT
-            ];
+        const concentrations =
+            clientSimulator.getCurrentConcentrations(productName);
+        const productConcentration = concentrations[productName];
+        const reactantConcentration = concentrations[ADJUSTABLE_AGENT];
 
         const currentTime = indexToTime(
             currentProductConcentrationArray.length,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,12 @@ import { ProductOverTimeTrace } from "./components/plots/types";
 import MainLayout from "./components/main-layout/Layout";
 import usePageNumber from "./hooks/usePageNumber";
 import fetch3DTrajectory from "./utils/fetch3DTrajectory";
-import { getColorIndex, insertValueSorted, updateArrayInState } from "./utils";
+import {
+    getColorIndex,
+    indexToTime,
+    insertValueSorted,
+    updateArrayInState,
+} from "./utils";
 import PreComputedPlotData from "./simulation/PreComputedPlotData";
 import PreComputedSimulationData from "./simulation/PreComputedSimulationData";
 import LiveSimulationData from "./simulation/LiveSimulationData";
@@ -459,8 +464,11 @@ function App() {
                 ADJUSTABLE_AGENT
             ];
 
-        const currentTime =
-            (bindingEventsOverTime.length * 10 * timeFactor) / 1000;
+        const currentTime = indexToTime(
+            currentProductConcentrationArray.length,
+            timeFactor,
+            simulationData.timeUnit
+        );
         const { newArray, index } = insertValueSorted(
             recordedReactantConcentrations,
             reactantConcentration

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -466,7 +466,7 @@ function App() {
             recordedReactantConcentrations,
             reactantConcentration
         );
-        setRecordedReactantConcentration(newArray as number[]);
+        setRecordedReactantConcentration(newArray);
         updateArrayInState(
             productEquilibriumConcentrations,
             index,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -446,7 +446,7 @@ function App() {
             setEquilibriumFeedbackTimeout("Not yet!");
             return false;
         }
-        // this will always be defined, for the current run, but since there are
+        // this will always be defined for the current run, but since there are
         // different agents in each module, typescript fears it will be undefined
         const currentInputConcentration = inputConcentration[ADJUSTABLE_AGENT];
         if (currentInputConcentration === undefined) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -446,7 +446,12 @@ function App() {
             setEquilibriumFeedbackTimeout("Not yet!");
             return false;
         }
+        // this will always be defined, for the current run, but since there are
+        // different agents in each module, typescript fears it will be undefined
         const currentInputConcentration = inputConcentration[ADJUSTABLE_AGENT];
+        if (currentInputConcentration === undefined) {
+            return false;
+        }
         const productConcentration =
             clientSimulator.getCurrentConcentrations(productName)[productName];
         const reactantConcentration =
@@ -470,7 +475,7 @@ function App() {
         updateArrayInState(
             recordedInputConcentration,
             index,
-            currentInputConcentration ?? 0,
+            currentInputConcentration,
             setRecordedInputConcentration
         );
         updateArrayInState(
@@ -482,7 +487,7 @@ function App() {
         const color =
             PLOT_COLORS[
                 getColorIndex(
-                    currentInputConcentration ?? 0,
+                    currentInputConcentration,
                     simulationData.getMaxConcentration(currentModule)
                 )
             ];

--- a/src/components/main-layout/CenterPanel.tsx
+++ b/src/components/main-layout/CenterPanel.tsx
@@ -2,14 +2,13 @@ import React from "react";
 import ViewSwitch from "../ViewSwitch";
 import EquilibriumQuestion from "../quiz-questions/EquilibriumQuestion";
 import KdQuestion from "../quiz-questions/KdQuestion";
-import { Module } from "../../types";
 import FinalPage from "../FinalPage";
 import VisibilityControl from "../shared/VisibilityControl";
 
 import styles from "./layout.module.css";
 
 interface CenterPanelProps {
-    reactionType: Module;
+    kd: number;
 }
 
 export const CenterPanelContext = React.createContext<{
@@ -19,7 +18,7 @@ export const CenterPanelContext = React.createContext<{
     lastOpened: "",
     setLastOpened: () => {},
 });
-const CenterPanel: React.FC<CenterPanelProps> = ({ reactionType }) => {
+const CenterPanel: React.FC<CenterPanelProps> = ({ kd }) => {
     const [lastOpened, setLastOpened] = React.useState<string | null>(null);
     return (
         <>
@@ -27,7 +26,7 @@ const CenterPanel: React.FC<CenterPanelProps> = ({ reactionType }) => {
             <CenterPanelContext.Provider value={{ lastOpened, setLastOpened }}>
                 <div className={styles.questionContainer}>
                     <EquilibriumQuestion />
-                    <KdQuestion reactionType={reactionType} />
+                    <KdQuestion kd={kd} />
                 </div>
             </CenterPanelContext.Provider>
             <VisibilityControl includedPages={[10]}>

--- a/src/components/main-layout/RightPanel.tsx
+++ b/src/components/main-layout/RightPanel.tsx
@@ -17,9 +17,12 @@ interface RightPanelProps {
     currentProductConcentrationArray: number[];
     currentAdjustableAgentConcentration: number;
     handleRecordEquilibrium: () => void;
-    equilibriumConcentrations: {
+    equilibriumData: {
         inputConcentrations: number[];
+        reactantConcentrations: number[];
         productConcentrations: number[];
+        timeToEquilibrium: number[];
+        colors: string[];
     };
     equilibriumFeedback: ReactNode | string;
     showHelpPanel: boolean;
@@ -28,7 +31,7 @@ interface RightPanelProps {
 const RightPanel: React.FC<RightPanelProps> = ({
     productOverTimeTraces,
     handleRecordEquilibrium,
-    equilibriumConcentrations,
+    equilibriumData,
     equilibriumFeedback,
     currentProductConcentrationArray,
     currentAdjustableAgentConcentration,
@@ -69,17 +72,21 @@ const RightPanel: React.FC<RightPanelProps> = ({
                         data={data}
                         width={width}
                         height={plotHeight}
+                        dotsX={equilibriumData.timeToEquilibrium}
+                        dotsY={equilibriumData.productConcentrations}
+                        colors={equilibriumData.colors}
                     />
                 </HelpPopup>
             </VisibilityControl>
 
             <VisibilityControl excludedPages={[0, 1, 2, 9]}>
-                <h3>Equilibrium concentration</h3>
+                <h3>Concentrations at equilibrium </h3>
                 <EquilibriumPlot
                     width={width}
                     height={plotHeight}
-                    x={equilibriumConcentrations.inputConcentrations}
-                    y={equilibriumConcentrations.productConcentrations}
+                    x={equilibriumData.reactantConcentrations}
+                    y={equilibriumData.productConcentrations}
+                    colors={equilibriumData.colors}
                 />
                 <div className={styles.recordButton}>
                     <RecordEquilibriumButton

--- a/src/components/main-layout/RightPanel.tsx
+++ b/src/components/main-layout/RightPanel.tsx
@@ -23,6 +23,7 @@ interface RightPanelProps {
         productConcentrations: number[];
         timeToEquilibrium: number[];
         colors: string[];
+        kd: number;
     };
     equilibriumFeedback: ReactNode | string;
     showHelpPanel: boolean;
@@ -87,6 +88,7 @@ const RightPanel: React.FC<RightPanelProps> = ({
                     x={equilibriumData.reactantConcentrations}
                     y={equilibriumData.productConcentrations}
                     colors={equilibriumData.colors}
+                    kd={equilibriumData.kd}
                 />
                 <div className={styles.recordButton}>
                     <RecordEquilibriumButton

--- a/src/components/plots/EquilibriumPlot.tsx
+++ b/src/components/plots/EquilibriumPlot.tsx
@@ -33,10 +33,8 @@ const EquilibriumPlot: React.FC<PlotProps> = ({
 }) => {
     const { maxConcentration } = useContext(SimulariumContext);
 
-    const maxPlusBuffer = maxConcentration + 1;
-
     const horizontalDottedLine = {
-        x: [0, maxPlusBuffer],
+        x: [0, kd * 2],
         y: [5, 5],
         mode: "lines",
         line: {

--- a/src/components/plots/EquilibriumPlot.tsx
+++ b/src/components/plots/EquilibriumPlot.tsx
@@ -20,6 +20,7 @@ interface PlotProps {
     height: number;
     width: number;
     colors: string[];
+    kd: number;
 }
 
 const EquilibriumPlot: React.FC<PlotProps> = ({
@@ -28,6 +29,7 @@ const EquilibriumPlot: React.FC<PlotProps> = ({
     height,
     width,
     colors,
+    kd,
 }) => {
     const { maxConcentration } = useContext(SimulariumContext);
 
@@ -67,7 +69,7 @@ const EquilibriumPlot: React.FC<PlotProps> = ({
         height: Math.max(130, height),
         xaxis: {
             ...AXIS_SETTINGS,
-            range: [0, 2],
+            range: [0, kd * 2],
             title: `[B] ${MICRO}M`,
             titlefont: {
                 ...AXIS_SETTINGS.titlefont,

--- a/src/components/plots/EquilibriumPlot.tsx
+++ b/src/components/plots/EquilibriumPlot.tsx
@@ -6,9 +6,7 @@ import {
     BASE_PLOT_LAYOUT,
     CONFIG,
     GRAY_COLOR,
-    PLOT_COLORS,
 } from "./constants";
-import { getColorIndex } from "./utils";
 import { SimulariumContext } from "../../simulation/context";
 import { AGENT_AB_COLOR, AGENT_B_COLOR } from "../../constants/colors";
 import { MICRO } from "../../constants";
@@ -21,13 +19,18 @@ interface PlotProps {
     y: number[];
     height: number;
     width: number;
+    colors: string[];
 }
 
-const EquilibriumPlot: React.FC<PlotProps> = ({ x, y, height, width }) => {
+const EquilibriumPlot: React.FC<PlotProps> = ({
+    x,
+    y,
+    height,
+    width,
+    colors,
+}) => {
     const { maxConcentration } = useContext(SimulariumContext);
-    const colors = x.map(
-        (value) => PLOT_COLORS[getColorIndex(value, maxConcentration)]
-    );
+
     const maxPlusBuffer = maxConcentration + 1;
 
     const horizontalDottedLine = {
@@ -64,7 +67,7 @@ const EquilibriumPlot: React.FC<PlotProps> = ({ x, y, height, width }) => {
         height: Math.max(130, height),
         xaxis: {
             ...AXIS_SETTINGS,
-            range: [0, maxPlusBuffer],
+            range: [0, 2],
             title: `[B] ${MICRO}M`,
             titlefont: {
                 ...AXIS_SETTINGS.titlefont,

--- a/src/components/plots/ProductConcentrationPlot.tsx
+++ b/src/components/plots/ProductConcentrationPlot.tsx
@@ -75,6 +75,7 @@ const ProductConcentrationPlot: React.FC<ProductConcentrationPlotProps> = ({
                 color: PLOT_COLORS[
                     getColorIndex(inputConcentration, maxConcentration)
                 ],
+                width: 1,
             },
         };
     });

--- a/src/components/plots/ProductConcentrationPlot.tsx
+++ b/src/components/plots/ProductConcentrationPlot.tsx
@@ -11,10 +11,10 @@ import {
 import { ProductOverTimeTrace } from "./types";
 import { SimulariumContext } from "../../simulation/context";
 import { AGENT_AB_COLOR } from "../../constants/colors";
-import { MICRO, NANO } from "../../constants";
+import { MICRO } from "../../constants";
 
 import plotStyles from "./plots.module.css";
-import { getColorIndex } from "../../utils";
+import { getColorIndex, indexToTime } from "../../utils";
 
 interface ProductConcentrationPlotProps {
     data: ProductOverTimeTrace[];
@@ -62,13 +62,9 @@ const ProductConcentrationPlot: React.FC<ProductConcentrationPlotProps> = ({
             hasData.current = lastValue > 0;
         }
 
-        const timeArray = productConcentrations.map((_, i) => {
-            if (timeUnit === NANO) {
-                return (i * timeFactor) / 1000;
-            } else {
-                return i * timeFactor;
-            }
-        });
+        const timeArray = productConcentrations.map((_, i) =>
+            indexToTime(i, timeFactor, timeUnit)
+        );
         return {
             x: timeArray,
             y: productConcentrations,

--- a/src/components/plots/ProductConcentrationPlot.tsx
+++ b/src/components/plots/ProductConcentrationPlot.tsx
@@ -8,26 +8,32 @@ import {
     CONFIG,
     PLOT_COLORS,
 } from "./constants";
-import { getColorIndex } from "./utils";
 import { ProductOverTimeTrace } from "./types";
 import { SimulariumContext } from "../../simulation/context";
 import { AGENT_AB_COLOR } from "../../constants/colors";
 import { MICRO, NANO } from "../../constants";
 
 import plotStyles from "./plots.module.css";
+import { getColorIndex } from "../../utils";
 
 interface ProductConcentrationPlotProps {
     data: ProductOverTimeTrace[];
     width: number;
     height: number;
+    colors: string[];
+    dotsX: number[];
+    dotsY: number[];
 }
 
 const ProductConcentrationPlot: React.FC<ProductConcentrationPlotProps> = ({
     data,
     width,
     height,
+    colors,
+    dotsX = [],
+    dotsY = [],
 }) => {
-    const { timeFactor, maxConcentration, productName, timeUnit } =
+    const { timeFactor, productName, timeUnit, maxConcentration } =
         useContext(SimulariumContext);
     const hasData = useRef(false);
     if (data.length === 0) {
@@ -76,6 +82,20 @@ const ProductConcentrationPlot: React.FC<ProductConcentrationPlotProps> = ({
             },
         };
     });
+
+    if (dotsX.length > 0) {
+        traces.push({
+            x: dotsX,
+            y: dotsY,
+            name: "",
+            type: "scatter" as const,
+            mode: "markers" as const,
+            marker: {
+                color: colors,
+                size: 8,
+            },
+        });
+    }
     /**
      * When there is no data, we want to show the axis at 0, 0, but plotly
      * defaults to -1.5 to 1.5 with no data, even when the range is set to
@@ -86,7 +106,6 @@ const ProductConcentrationPlot: React.FC<ProductConcentrationPlotProps> = ({
         ...BASE_PLOT_LAYOUT,
         width: width,
         height: Math.max(130, height),
-
         xaxis: {
             ...AXIS_SETTINGS,
             range: range,

--- a/src/components/plots/utils.ts
+++ b/src/components/plots/utils.ts
@@ -1,6 +1,0 @@
-import { PLOT_COLORS } from "./constants";
-
-export const getColorIndex = (value: number | string, maxValue: number) => {
-    // this is dividing by 2 because the value is always an even number
-    return Math.floor((Number(value) / 2 / maxValue) * 10) % PLOT_COLORS.length;
-};

--- a/src/components/quiz-questions/KdQuestion.tsx
+++ b/src/components/quiz-questions/KdQuestion.tsx
@@ -7,6 +7,7 @@ import VisibilityControl from "../shared/VisibilityControl";
 import InputNumber from "../shared/InputNumber";
 import { FormState } from "./types";
 import styles from "./popup.module.css";
+import { MICRO } from "../../constants";
 interface KdQuestionProps {
     kd: number;
 }

--- a/src/components/quiz-questions/KdQuestion.tsx
+++ b/src/components/quiz-questions/KdQuestion.tsx
@@ -8,14 +8,13 @@ import InputNumber from "../shared/InputNumber";
 import { FormState } from "./types";
 import styles from "./popup.module.css";
 import { MICRO } from "../../constants";
-interface KdQuestionProps {
 
-const KdQuestion: React.FC<KdQuestionProps> = ({ kd, canAnswer }) => {
+interface KdQuestionProps {
     kd: number;
     canAnswer: boolean;
 }
 
-const KdQuestion: React.FC<KdQuestionProps> = ({ reactionType, canAnswer }) => {
+const KdQuestion: React.FC<KdQuestionProps> = ({ kd, canAnswer }) => {
     const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
     const [formState, setFormState] = useState(FormState.Clear);
 

--- a/src/components/quiz-questions/KdQuestion.tsx
+++ b/src/components/quiz-questions/KdQuestion.tsx
@@ -4,15 +4,13 @@ import { valueType } from "antd/es/statistic/utils";
 import QuizForm from "./QuizForm";
 import VisibilityControl from "../shared/VisibilityControl";
 import InputNumber from "../shared/InputNumber";
-import { kds } from "../../constants";
 import { FormState } from "./types";
 import styles from "./popup.module.css";
-import { Module } from "../../types";
 interface KdQuestionProps {
-    reactionType: Module;
+    kd: number;
 }
 
-const KdQuestion: React.FC<KdQuestionProps> = ({ reactionType }) => {
+const KdQuestion: React.FC<KdQuestionProps> = ({ kd }) => {
     const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
     const [formState, setFormState] = useState(FormState.Clear);
 
@@ -27,7 +25,7 @@ const KdQuestion: React.FC<KdQuestionProps> = ({ reactionType }) => {
         }
     };
     const handleSubmit = () => {
-        const correctAnswer = kds[reactionType];
+        const correctAnswer = kd;
         const tolerance = 1.5;
         if (selectedAnswer === null) {
             // No answer selected

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,11 +1,3 @@
-import { Module } from "../types";
-
-export const kds = {
-    [Module.A_B_AB]: 1,
-    [Module.A_C_AC]: 10,
-    [Module.A_B_C_AB_AC]: 5,
-};
-
 export const MICRO = String.fromCharCode(956);
 export const NANO = "n";
 export const DEFAULT_VIEWPORT_SIZE = { width: 500, height: 500 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,7 +1,7 @@
 import { Module } from "../types";
 
 export const kds = {
-    [Module.A_B_AB]: 6,
+    [Module.A_B_AB]: 1,
     [Module.A_C_AC]: 10,
     [Module.A_B_C_AB_AC]: 5,
 };

--- a/src/simulation/LiveSimulationData.ts
+++ b/src/simulation/LiveSimulationData.ts
@@ -48,6 +48,12 @@ const agentC: InputAgent = {
     color: AGENT_C_COLOR,
 };
 
+const kds = {
+    [Module.A_B_AB]: 1,
+    [Module.A_C_AC]: 10,
+    [Module.A_B_C_AB_AC]: 5,
+};
+
 export default class LiveSimulation implements ISimulationData {
     static NAME_TO_FUNCTION_MAP = {
         [AgentName.A]: AgentFunction.Fixed,
@@ -64,7 +70,7 @@ export default class LiveSimulation implements ISimulationData {
     };
     static INITIAL_CONCENTRATIONS = {
         [AgentName.A]: 10,
-        [AgentName.B]: 6,
+        [AgentName.B]: 4,
         [AgentName.C]: 10,
     };
     PRODUCT = {
@@ -154,5 +160,8 @@ export default class LiveSimulation implements ISimulationData {
                     ],
             };
         }, {});
+    };
+    getKd = (module: Module): number => {
+        return kds[module];
     };
 }

--- a/src/simulation/LiveSimulationData.ts
+++ b/src/simulation/LiveSimulationData.ts
@@ -33,7 +33,7 @@ const agentB: InputAgent = {
     radius: 0.7,
     partners: [0],
     kOn: 0.6,
-    kOff: 0.2,
+    kOff: 0.5,
     color: AGENT_B_COLOR,
 };
 

--- a/src/simulation/PreComputedSimulationData.ts
+++ b/src/simulation/PreComputedSimulationData.ts
@@ -81,4 +81,7 @@ export default class PreComputedSimulationData implements ISimulationData {
     createAgentsFromConcentrations = (): InputAgent[] | null => {
         return null;
     };
+    getKd = (): number => {
+        return 0;
+    };
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { sortedIndex } from "lodash";
 import { PLOT_COLORS } from "../components/plots/constants";
+import { NANO } from "../constants";
 
 export const insertIntoArray = <T>(
     array: T[],
@@ -30,4 +31,16 @@ export const updateArrayInState = <T>(
 export const getColorIndex = (value: number | string, maxValue: number) => {
     // this is dividing by 2 because the value is always an even number
     return Math.floor((Number(value) / 2 / maxValue) * 10) % PLOT_COLORS.length;
+};
+
+export const indexToTime = (
+    index: number,
+    timeFactor: number,
+    timeUnit: string
+) => {
+    if (timeUnit === NANO) {
+        return (index * timeFactor) / 1000;
+    } else {
+        return index * timeFactor;
+    }
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { sortedIndex } from "lodash";
+import { PLOT_COLORS } from "../components/plots/constants";
 
 export const insertIntoArray = <T>(
     array: T[],
@@ -14,4 +15,19 @@ export const insertValueSorted = (
 ): { newArray: number[]; index: number } => {
     const index = sortedIndex(array, value);
     return { newArray: insertIntoArray(array, index, value), index };
+};
+
+export const updateArrayInState = <T>(
+    array: T[],
+    index: number,
+    value: T,
+    setArray: (arg0: T[]) => void
+) => {
+    const newArray = insertIntoArray(array, index, value);
+    setArray(newArray);
+};
+
+export const getColorIndex = (value: number | string, maxValue: number) => {
+    // this is dividing by 2 because the value is always an even number
+    return Math.floor((Number(value) / 2 / maxValue) * 10) % PLOT_COLORS.length;
 };


### PR DESCRIPTION
Problem
=======
Estimated review size: large


What is the problem this work solves, including
closes #61 
there was a bug where we were using the starting concentration of B instead of the live concentration of B to calculate the Kd. So reworking that required changes to how we're storing the data 

Solution
========
This data is a series of arrays that are all matched in indices. I did this instead of storing this data as an object that I then have to unpack as separate arrays for the plots. I do have to go over them once to make sure all the data has the correct index, but they also have to be sorted in order of the reactantConcentrations, so I'm saving one pass over the data by storing it way. 


   `equilibriumData`
                                    inputConcentrations 
                                    reactantConcentrations **(new array)**
                                    productConcentrations
                                    timeToEquilibrium **(new array, needed to store the dots on the product conc over time plot)**
                                    colors **(new array, it's created by the inputConcentrations, and then the index for other arrays is used to sync colors**
                                    kd **added because it was needed in more than one component** 

graphs: 
- product over time 
`time` v `productOverTimeArray` 
`timeToEquilibrium` v `productConcentrations` ==> shows dots were the user stored a value

- Concentration at equilibrium 
`reactantConcentrations` v `productConcentrations`


## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)



Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing

Screenshots (optional):
-----------------------
<img width="1114" alt="Screenshot 2024-09-30 at 9 39 22 PM" src="https://github.com/user-attachments/assets/4ea6e819-89cc-4a59-bc10-033f3acf0761">
