### PR TITLE
Fix/move playbuttons

### DIFF
--- a/src/components/PlayButton.tsx
+++ b/src/components/PlayButton.tsx
@@ -13,14 +13,20 @@ const PlayButton: React.FC = () => {
         setIsPlaying(!isPlaying);
     };
 
+    const iconStyle = { fontSize: 26 };
+
     return (
         <VisibilityControl excludedPages={[1, 10, 11]}>
             <ProgressionControl onPage={[2, 5]}>
                 <OverlayButton
                     onClick={handleClick}
-                    style={{ top: 14, left: 16, fontSize: 26 }}
+                    style={{ top: 14, left: 16 }}
                     icon={
-                        isPlaying ? <PauseOutlined /> : <CaretRightOutlined />
+                        isPlaying ? (
+                            <PauseOutlined style={iconStyle} />
+                        ) : (
+                            <CaretRightOutlined style={iconStyle} />
+                        )
                     }
                 />
             </ProgressionControl>

--- a/src/components/PlayButton.tsx
+++ b/src/components/PlayButton.tsx
@@ -18,7 +18,7 @@ const PlayButton: React.FC = () => {
             <ProgressionControl onPage={[2, 5]}>
                 <OverlayButton
                     onClick={handleClick}
-                    style={{ bottom: 14, left: 16 }}
+                    style={{ top: 14, left: 16 }}
                     icon={
                         isPlaying ? <PauseOutlined /> : <CaretRightOutlined />
                     }

--- a/src/components/PlayButton.tsx
+++ b/src/components/PlayButton.tsx
@@ -18,7 +18,7 @@ const PlayButton: React.FC = () => {
             <ProgressionControl onPage={[2, 5]}>
                 <OverlayButton
                     onClick={handleClick}
-                    style={{ top: 14, left: 16 }}
+                    style={{ top: 14, left: 16, fontSize: 26 }}
                     icon={
                         isPlaying ? <PauseOutlined /> : <CaretRightOutlined />
                     }

--- a/src/components/ViewSwitch.tsx
+++ b/src/components/ViewSwitch.tsx
@@ -38,7 +38,7 @@ const ViewSwitch: React.FC = () => {
 
     let buttonStyle: React.CSSProperties = {
         top: 16,
-        left: 16,
+        right: 16,
         // by default, antd animates everything, and this button moves, so we're only animating
         // the hover color change and not the position change
         transition:
@@ -48,8 +48,8 @@ const ViewSwitch: React.FC = () => {
     if (page === 1) {
         buttonStyle = {
             ...buttonStyle,
-            left: "50%",
-            transform: "translateX(-50%)",
+            right: "50%",
+            transform: "translateX(50%)",
         };
     }
 

--- a/src/components/ViewSwitch.tsx
+++ b/src/components/ViewSwitch.tsx
@@ -36,7 +36,7 @@ const ViewSwitch: React.FC = () => {
         }
     );
 
-    let buttonStyle = {
+    let buttonStyle: React.CSSProperties = {
         top: 16,
         left: 16,
         // by default, antd animates everything, and this button moves, so we're only animating
@@ -46,8 +46,11 @@ const ViewSwitch: React.FC = () => {
     };
 
     if (page === 1) {
-        const siderWidth = window.innerWidth * 0.25;
-        buttonStyle = { ...buttonStyle, left: -siderWidth + buttonStyle.left };
+        buttonStyle = {
+            ...buttonStyle,
+            left: "50%",
+            transform: "translateX(-50%)",
+        };
     }
 
     return (
@@ -65,8 +68,7 @@ const ViewSwitch: React.FC = () => {
                             )
                         }
                     >
-                        Switch to{" "}
-                        {currentView === View.Lab ? "molecular" : "lab"} view
+                        {currentView === View.Lab ? "Molecular" : "Lab"} view
                     </OverlayButton>
                 </ProgressionControl>
             </VisibilityControl>


### PR DESCRIPTION
Problem
=======
Estimated review size: small

#119 
people were having trouble noticing the play button 

Solution
========
increased the size of the icon and moved it. We also centered the initial switch button 
[new design](https://www.figma.com/design/KEEHjYRxL9ouTuceTtyC7G/2024-Feb-Interactive-Publication?node-id=854-60931&node-type=frame&t=6RjGY4Z7FZlleaem-0) 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Screenshots (optional):
-----------------------
![Uploading Screenshot 2024-10-02 at 11.01.11 AM.png…]()

