### PR TITLE
adding kd definition and removed a page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,11 +263,6 @@ function App() {
             page === 4 && uniqMeasuredConcentrations.length > 0 && !isPlaying,
         () => setPage(5)
     );
-    usePageNumber(
-        page,
-        (page) => canDetermineEquilibrium && page === 7,
-        () => setPage(8)
-    );
 
     usePageNumber(
         page,
@@ -491,6 +486,14 @@ function App() {
                             <ContentPanel
                                 title={moduleNames[currentModule]}
                                 {...content[currentModule][page]}
+                                finishButton={
+                                    (canDetermineEquilibrium &&
+                                        page <
+                                            PAGE_NUMBER_3D_EXAMPLE[
+                                                currentModule
+                                            ]) ||
+                                    content[currentModule][page].finishButton
+                                }
                             />
                         }
                         reactionPanel={
@@ -514,7 +517,12 @@ function App() {
                             />
                         }
                         centerPanel={
-                            <CenterPanel reactionType={currentModule} />
+                            <CenterPanel
+                                reactionType={currentModule}
+                                canDetermineEquilibrium={
+                                    canDetermineEquilibrium
+                                }
+                            />
                         }
                         rightPanel={
                             <RightPanel

--- a/src/components/main-layout/CenterPanel.tsx
+++ b/src/components/main-layout/CenterPanel.tsx
@@ -10,6 +10,7 @@ import styles from "./layout.module.css";
 
 interface CenterPanelProps {
     reactionType: Module;
+    canDetermineEquilibrium: boolean;
 }
 
 export const CenterPanelContext = React.createContext<{
@@ -19,7 +20,10 @@ export const CenterPanelContext = React.createContext<{
     lastOpened: "",
     setLastOpened: () => {},
 });
-const CenterPanel: React.FC<CenterPanelProps> = ({ reactionType }) => {
+const CenterPanel: React.FC<CenterPanelProps> = ({
+    reactionType,
+    canDetermineEquilibrium,
+}) => {
     const [lastOpened, setLastOpened] = React.useState<string | null>(null);
     return (
         <>
@@ -27,10 +31,13 @@ const CenterPanel: React.FC<CenterPanelProps> = ({ reactionType }) => {
             <CenterPanelContext.Provider value={{ lastOpened, setLastOpened }}>
                 <div className={styles.questionContainer}>
                     <EquilibriumQuestion />
-                    <KdQuestion reactionType={reactionType} />
+                    <KdQuestion
+                        reactionType={reactionType}
+                        canAnswer={canDetermineEquilibrium}
+                    />
                 </div>
             </CenterPanelContext.Provider>
-            <VisibilityControl includedPages={[10]}>
+            <VisibilityControl includedPages={[9]}>
                 <FinalPage />
             </VisibilityControl>
         </>

--- a/src/components/main-layout/ContentPanel.tsx
+++ b/src/components/main-layout/ContentPanel.tsx
@@ -6,7 +6,6 @@ import BackButton from "../shared/BackButton";
 
 import styles from "./layout.module.css";
 import { SimulariumContext } from "../../simulation/context";
-import { PillButton } from "../shared/ButtonLibrary";
 
 export interface ContentPanelProps {
     content: string | JSX.Element;
@@ -44,14 +43,11 @@ const ContentPanel: React.FC<ContentPanelProps> = ({
             <div className={styles.contentPanelText}>
                 <h3>{header}</h3>
                 <p>{content}</p>
-                {
-                    <Flex gap={12} align="center">
-                        <PillButton size="small" ghost className="inline-pill">
-                            Learn how to derive K<sub>d</sub>
-                        </PillButton>
-                        {moreInfo && <span>{moreInfo}</span>}
-                    </Flex>
-                }
+
+                {moreInfo && (
+                    <span className={styles.moreInfo}>{moreInfo}</span>
+                )}
+
                 {callToAction && (
                     <p className={styles.callToActionP}>
                         <PointerIcon /> <span>{callToAction}</span>

--- a/src/components/main-layout/ContentPanel.tsx
+++ b/src/components/main-layout/ContentPanel.tsx
@@ -6,11 +6,17 @@ import BackButton from "../shared/BackButton";
 
 import styles from "./layout.module.css";
 import { SimulariumContext } from "../../simulation/context";
+import { PillButton } from "../shared/ButtonLibrary";
 
 export interface ContentPanelProps {
     content: string | JSX.Element;
     title?: string;
     callToAction?: string | JSX.Element;
+    modal?: {
+        buttonText: string;
+        content: string | JSX.Element;
+    };
+    moreInfo?: string | JSX.Element;
     nextButton?: boolean;
     backButton?: boolean;
     finishButton?: boolean;
@@ -23,6 +29,7 @@ const ContentPanel: React.FC<ContentPanelProps> = ({
     backButton,
     nextButton,
     finishButton,
+    moreInfo,
 }) => {
     const showButton = nextButton || finishButton;
     const { exampleTrajectoryPageNumber, page } = useContext(SimulariumContext);
@@ -37,6 +44,14 @@ const ContentPanel: React.FC<ContentPanelProps> = ({
             <div className={styles.contentPanelText}>
                 <h3>{header}</h3>
                 <p>{content}</p>
+                {
+                    <Flex gap={12} align="center">
+                        <PillButton size="small" ghost className="inline-pill">
+                            Learn how to derive K<sub>d</sub>
+                        </PillButton>
+                        {moreInfo && <span>{moreInfo}</span>}
+                    </Flex>
+                }
                 {callToAction && (
                     <p className={styles.callToActionP}>
                         <PointerIcon /> <span>{callToAction}</span>

--- a/src/components/main-layout/ContentPanel.tsx
+++ b/src/components/main-layout/ContentPanel.tsx
@@ -11,10 +11,6 @@ export interface ContentPanelProps {
     content: string | JSX.Element;
     title?: string;
     callToAction?: string | JSX.Element;
-    modal?: {
-        buttonText: string;
-        content: string | JSX.Element;
-    };
     moreInfo?: string | JSX.Element;
     nextButton?: boolean;
     backButton?: boolean;

--- a/src/components/main-layout/Layout.tsx
+++ b/src/components/main-layout/Layout.tsx
@@ -33,21 +33,19 @@ const MainLayout: React.FC<MainLayoutProps> = ({
                 className={classNames([
                     styles.contentPanel,
                     {
-                        [styles.finalPage]: page === 11,
+                        [styles.finalPage]: page === 10,
                     },
                 ])}
             >
                 {content}
             </Content>
-            <VisibilityControl
-                excludedPages={[exampleTrajectoryPageNumber, 10, 11]}
-            >
+            <VisibilityControl notInBonusMaterial>
                 <Header className={styles.reactionPanel}>
                     {reactionPanel}
                 </Header>
             </VisibilityControl>
             <Layout>
-                <VisibilityControl excludedPages={[10, 11]}>
+                <VisibilityControl excludedPages={[9, 10]}>
                     <Sider
                         className={classNames([
                             styles.sidePanel,
@@ -64,7 +62,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({
                 </VisibilityControl>
 
                 <Content className={styles.centerPanel}>{centerPanel}</Content>
-                <VisibilityControl excludedPages={[10, 11]}>
+                <VisibilityControl excludedPages={[9, 10]}>
                     <Sider
                         className={classNames([
                             styles.sidePanel,

--- a/src/components/main-layout/LeftPanel.tsx
+++ b/src/components/main-layout/LeftPanel.tsx
@@ -39,7 +39,7 @@ const LeftPanel: React.FC<LeftPanelProps> = ({
                     adjustableAgent={adjustableAgent}
                 />
             </VisibilityControl>
-            <VisibilityControl excludedPages={[0, 1, 2, 9]}>
+            <VisibilityControl excludedPages={[0, 1, 2]} notInBonusMaterial>
                 <EventsOverTimePlot
                     bindingEventsOverTime={bindingEventsOverTime}
                     unbindingEventsOverTime={unbindingEventsOverTime}

--- a/src/components/main-layout/RightPanel.tsx
+++ b/src/components/main-layout/RightPanel.tsx
@@ -73,7 +73,7 @@ const RightPanel: React.FC<RightPanelProps> = ({
                 </HelpPopup>
             </VisibilityControl>
 
-            <VisibilityControl excludedPages={[0, 1, 2, 9]}>
+            <VisibilityControl excludedPages={[0, 1, 2]} notInBonusMaterial>
                 <h3>Equilibrium concentration</h3>
                 <EquilibriumPlot
                     width={width}

--- a/src/components/main-layout/layout.module.css
+++ b/src/components/main-layout/layout.module.css
@@ -25,6 +25,10 @@
     margin: 0;
 }
 
+.content-panel .more-info {
+    font-size: 12px;
+}
+
 .call-to-action-p {
     display: flex;
     gap: 8px;

--- a/src/components/quiz-questions/EquilibriumQuestion.tsx
+++ b/src/components/quiz-questions/EquilibriumQuestion.tsx
@@ -60,7 +60,7 @@ const EquilibriumQuestion: React.FC = () => {
     );
 
     return (
-        <VisibilityControl includedPages={[4, 5, 6, 7, 8]}>
+        <VisibilityControl excludedPages={[1, 2, 3]} notInBonusMaterial>
             <QuizForm
                 title="Which of the following is true about the reaction at equilibrium?"
                 formContent={formContent}

--- a/src/components/quiz-questions/KdQuestion.tsx
+++ b/src/components/quiz-questions/KdQuestion.tsx
@@ -11,9 +11,10 @@ import styles from "./popup.module.css";
 import { Module } from "../../types";
 interface KdQuestionProps {
     reactionType: Module;
+    canAnswer: boolean;
 }
 
-const KdQuestion: React.FC<KdQuestionProps> = ({ reactionType }) => {
+const KdQuestion: React.FC<KdQuestionProps> = ({ reactionType, canAnswer }) => {
     const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
     const [formState, setFormState] = useState(FormState.Clear);
 
@@ -55,24 +56,27 @@ const KdQuestion: React.FC<KdQuestionProps> = ({ reactionType }) => {
     const formContent = (
         <div className={styles.inputFormContent}>
             <p id="kd question">
-                Referencing the Equilibrium Concentration plot, what is the
-                binding affinity? (K<sub>d</sub> = ?)
+                You have now measured enough points to estimate the value of B
+                where half of the binding sites of A are occupied.
             </p>
-            <Flex gap={8} align="baseline" style={{ maxWidth: 230 }}>
+            <b>
+                K<sub>d</sub> = ?
+            </b>
+            <Flex gap={8} align="baseline" style={{ maxWidth: 130 }}>
                 <InputNumber
                     aria-labelledby="kd question"
                     value={selectedAnswer || ""}
                     onChange={handleAnswerSelection}
-                    placeholder="Type approximate value..."
+                    placeholder="Type value..."
                 />
                 <span> {MICRO}M</span>
             </Flex>
         </div>
     );
     return (
-        <VisibilityControl includedPages={[8]}>
+        <VisibilityControl conditionalRender={canAnswer} notInBonusMaterial>
             <QuizForm
-                title="You have now measured enough points to estimate the value of B where half of the binding sites of A are occupied."
+                title="What is the binding affinity?"
                 formContent={formContent}
                 onSubmit={handleSubmit}
                 successMessage="A and B have a high affinity for one another."

--- a/src/components/shared/ButtonLibrary.tsx
+++ b/src/components/shared/ButtonLibrary.tsx
@@ -49,9 +49,9 @@ export const TertiaryButton: React.FC<ButtonProps> = (props) => {
 export const PillButton: React.FC<ButtonProps> = (props) => {
     return (
         <AntdButton
+            size="large"
             {...props}
             shape="round"
-            size="large"
             className={classNames(props.className, styles.tertiary)}
         />
     );

--- a/src/components/shared/VisibilityControl.tsx
+++ b/src/components/shared/VisibilityControl.tsx
@@ -5,20 +5,35 @@ interface VisibilityControlProps {
     excludedPages?: number[];
     children: React.ReactNode;
     includedPages?: number[];
+    conditionalRender?: boolean;
+    notInBonusMaterial?: boolean;
 }
 
 const VisibilityControl: React.FC<VisibilityControlProps> = ({
     excludedPages,
     children,
     includedPages,
+    conditionalRender,
+    notInBonusMaterial,
 }) => {
-    const { page } = useContext(SimulariumContext);
+    const { page, exampleTrajectoryPageNumber } = useContext(SimulariumContext);
+    if (conditionalRender === false) {
+        return null;
+    }
 
     let shouldRender = true;
+
     if (includedPages) {
         shouldRender = includedPages.includes(page);
     } else if (excludedPages) {
         shouldRender = !excludedPages.includes(page);
+    }
+    if (
+        notInBonusMaterial !== undefined &&
+        notInBonusMaterial &&
+        page >= exampleTrajectoryPageNumber
+    ) {
+        shouldRender = false;
     }
 
     return shouldRender ? <>{children}</> : null;

--- a/src/components/shared/VisibilityControl.tsx
+++ b/src/components/shared/VisibilityControl.tsx
@@ -28,11 +28,7 @@ const VisibilityControl: React.FC<VisibilityControlProps> = ({
     } else if (excludedPages) {
         shouldRender = !excludedPages.includes(page);
     }
-    if (
-        notInBonusMaterial !== undefined &&
-        notInBonusMaterial &&
-        page >= exampleTrajectoryPageNumber
-    ) {
+    if (notInBonusMaterial && page >= exampleTrajectoryPageNumber) {
         shouldRender = false;
     }
 

--- a/src/components/shared/button-library.module.css
+++ b/src/components/shared/button-library.module.css
@@ -49,3 +49,7 @@
     display: flex;
     align-items: center;
 }
+
+:global(.inline-pill) {
+    height: 31px;
+}

--- a/src/content/glossary.tsx
+++ b/src/content/glossary.tsx
@@ -1,17 +1,17 @@
 export const terms = {
     affinity: {
         definition:
-            "Measure of the strength of an interaction between two molecules. Generally, the more chemical bonds that form between two molecules, the stronger the affinity of those molecules for each other.",
+            "The strength of an interaction between two molecules. Two molecules that have high affinity stay bound to each other for longer than two molecules that have low affinity for each other.",
         link: undefined,
     },
     KD: {
         definition:
-            "The equilibrium constant. The balance of products and reactants at equilibrium, defined mathematically as the ratio of the dissociation and association rate constants, which quantitatively measures affinity.",
+            "The dissociation constant defines the propensity of a complex to fall apart into its smaller components. A reaction with a high Kd means the components have a low affinity, and are more likely to fall apart. A low Kd means the components have a high affinity, and spend more time as a complex.",
         link: "https://www.khanacademy.org/science/ap-chemistry-beta/x2eef969c74e0d802:equilibrium/x2eef969c74e0d802:magnitude-and-properties-of-the-equilibrium-constant/v/magnitude-of-the-equilibrium-constant",
     },
     equilibrium: {
         definition:
-            "The state in which the amount of reactants and products of a reaction are not changing over time.",
+            "The state in which the rate of the forward reaction is the same as the reverse reaction",
         link: "https://www.khanacademy.org/science/ap-chemistry-beta/x2eef969c74e0d802:equilibrium/x2eef969c74e0d802:introduction-to-equilibrium/v/dynamic-equilibrium",
     },
     "reaction rate equation": {

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -1,9 +1,7 @@
-import { Flex } from "antd";
 import { A, AB, B } from "../components/agent-symbols";
 import { ContentPanelProps } from "../components/main-layout/ContentPanel";
 import Definition from "../components/shared/Definition";
 import { Module } from "../types";
-import { PillButton } from "../components/shared/ButtonLibrary";
 
 export const highAffinityContentArray: ContentPanelProps[] = [
     // making the content array 1 indexed to match the page numbers
@@ -97,9 +95,7 @@ export const highAffinityContentArray: ContentPanelProps[] = [
                 />{" "}
                 to compare affinities. K<sub>d</sub> can by determined in this
                 experiment by finding the concentration of <B /> at equilibrium
-                where half the binding sites of <A /> are occupied. (Which is
-                where [<AB />] = [<A />
-                ]).
+                where half the binding sites of <A /> are occupied.
             </>
         ),
         modal: {
@@ -148,18 +144,6 @@ export const highAffinityContentArray: ContentPanelProps[] = [
         ),
     },
     {
-        content: (
-            <>
-                How do the different substrate concentrations of <B /> affect
-                the reaction? Are there any similarities between the reactions
-                when they reach equilibrium? Are there any differences?
-            </>
-        ),
-        callToAction:
-            "Test your knowledge and calculate the binding affinity below before moving on.",
-        nextButton: true,
-    },
-    {
         title: "Real-world example: Antibodies and antigens, high affinity binders",
         content: (
             <>
@@ -201,7 +185,7 @@ export const moduleNames = {
 };
 
 export const PAGE_NUMBER_3D_EXAMPLE = {
-    [Module.A_B_AB]: 9,
+    [Module.A_B_AB]: 8,
     [Module.A_C_AC]: 9,
     [Module.A_B_C_AB_AC]: 9,
 };

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -96,6 +96,10 @@ export const highAffinityContentArray: ContentPanelProps[] = [
                 to compare affinities. K<sub>d</sub> is the concentration of{" "}
                 <B /> where half the binding sites of <A /> are occupied at
                 equilibrium.
+                <div>
+                    K<sub>d</sub> = [<B />] at equilibrium when 50% of <A /> is
+                    bound to <B />
+                </div>
             </>
         ),
         callToAction: (

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -96,7 +96,9 @@ export const highAffinityContentArray: ContentPanelProps[] = [
                 />{" "}
                 to compare affinities. K<sub>d</sub> can by determined in this
                 experiment by finding the concentration of <B /> at equilibrium
-                where half the binding sites of <A /> are occupied.
+                where half the binding sites of <A /> are occupied. (Which is
+                where [<AB />] = [<A />
+                ])
                 <Flex>
                     <div>
                         K<sub>d</sub> = [<B />] at equilibrium when 50% of <A />{" "}

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -33,7 +33,7 @@ export const highAffinityContentArray: ContentPanelProps[] = [
                 molecule changes rapidly as the two molecules, <A /> and <B />,
                 bind to form <AB />. Eventually, the reaction reaches{" "}
                 <Definition term="equilibrium" />, at which point the
-                concentration of AB stays more or less consistent.
+                concentration of <AB /> stays more or less consistent.
             </>
         ),
         callToAction:
@@ -94,9 +94,9 @@ export const highAffinityContentArray: ContentPanelProps[] = [
                         </>
                     }
                 />{" "}
-                to compare affinities. K<sub>d</sub> is the concentration of{" "}
-                <B /> at equilibrium where half the binding sites of <A /> are
-                occupied.
+                to compare affinities. K<sub>d</sub> can by determined in this
+                experiment by finding the concentration of <B /> at equilibrium
+                where half the binding sites of <A /> are occupied.
                 <Flex>
                     <div>
                         K<sub>d</sub> = [<B />] at equilibrium when 50% of <A />{" "}

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -3,6 +3,7 @@ import { A, AB, B } from "../components/agent-symbols";
 import { ContentPanelProps } from "../components/main-layout/ContentPanel";
 import Definition from "../components/shared/Definition";
 import { Module } from "../types";
+import { PillButton } from "../components/shared/ButtonLibrary";
 
 export const highAffinityContentArray: ContentPanelProps[] = [
     // making the content array 1 indexed to match the page numbers
@@ -98,13 +99,44 @@ export const highAffinityContentArray: ContentPanelProps[] = [
                 experiment by finding the concentration of <B /> at equilibrium
                 where half the binding sites of <A /> are occupied. (Which is
                 where [<AB />] = [<A />
-                ])
-                <Flex>
-                    <div>
-                        K<sub>d</sub> = [<B />] at equilibrium when 50% of <A />{" "}
-                        is bound to <B />
-                    </div>
-                </Flex>
+                ]).
+            </>
+        ),
+        modal: {
+            buttonText: "Learn how to derive Kd",
+            content: (
+                <>
+                    <p>
+                        The dissociation constant (K<sub>d</sub>) is a measure
+                        of the propensity of a complex to fall apart into its
+                        smaller components. A reaction with a high K<sub>d</sub>{" "}
+                        means the components have a low affinity and are more
+                        likely to fall apart. A low K<sub>d</sub> means the
+                        components have a high affinity and spend more time as a
+                        complex.
+                    </p>
+                    <p>
+                        In this experiment, K<sub>d</sub> is the concentration
+                        of
+                        <B /> at equilibrium when 50% of <A /> is bound to <B />
+                        .
+                    </p>
+                    <p>
+                        <a
+                            href="https://www.khanacademy.org/science/ap-chemistry-beta/x2eef969c74e0d802:equilibrium/x2eef969c74e0d802:magnitude-and-properties-of-the-equilibrium-constant/v/magnitude-of-the-equilibrium-constant"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Learn more about K<sub>d</sub> on Khan Academy
+                        </a>
+                    </p>
+                </>
+            ),
+        },
+        moreInfo: (
+            <>
+                K<sub>d</sub> = [<B />] (at equilibrium when 50% of <A /> is
+                bound to <B />)
             </>
         ),
         callToAction: (

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -98,37 +98,6 @@ export const highAffinityContentArray: ContentPanelProps[] = [
                 where half the binding sites of <A /> are occupied.
             </>
         ),
-        modal: {
-            buttonText: "Learn how to derive Kd",
-            content: (
-                <>
-                    <p>
-                        The dissociation constant (K<sub>d</sub>) is a measure
-                        of the propensity of a complex to fall apart into its
-                        smaller components. A reaction with a high K<sub>d</sub>{" "}
-                        means the components have a low affinity and are more
-                        likely to fall apart. A low K<sub>d</sub> means the
-                        components have a high affinity and spend more time as a
-                        complex.
-                    </p>
-                    <p>
-                        In this experiment, K<sub>d</sub> is the concentration
-                        of
-                        <B /> at equilibrium when 50% of <A /> is bound to <B />
-                        .
-                    </p>
-                    <p>
-                        <a
-                            href="https://www.khanacademy.org/science/ap-chemistry-beta/x2eef969c74e0d802:equilibrium/x2eef969c74e0d802:magnitude-and-properties-of-the-equilibrium-constant/v/magnitude-of-the-equilibrium-constant"
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            Learn more about K<sub>d</sub> on Khan Academy
-                        </a>
-                    </p>
-                </>
-            ),
-        },
         moreInfo: (
             <>
                 K<sub>d</sub> = [<B />] (at equilibrium when 50% of <A /> is

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -1,3 +1,4 @@
+import { Flex } from "antd";
 import { A, AB, B } from "../components/agent-symbols";
 import { ContentPanelProps } from "../components/main-layout/ContentPanel";
 import Definition from "../components/shared/Definition";
@@ -94,12 +95,14 @@ export const highAffinityContentArray: ContentPanelProps[] = [
                     }
                 />{" "}
                 to compare affinities. K<sub>d</sub> is the concentration of{" "}
-                <B /> where half the binding sites of <A /> are occupied at
-                equilibrium.
-                <div>
-                    K<sub>d</sub> = [<B />] at equilibrium when 50% of <A /> is
-                    bound to <B />
-                </div>
+                <B /> at equilibrium where half the binding sites of <A /> are
+                occupied.
+                <Flex>
+                    <div>
+                        K<sub>d</sub> = [<B />] at equilibrium when 50% of <A />{" "}
+                        is bound to <B />
+                    </div>
+                </Flex>
             </>
         ),
         callToAction: (


### PR DESCRIPTION
Problem
=======
Estimated review size: medium

The designs had a definition of Kd that I hadn't included yet. 
The new designs removed a page from the content and kept the kd definition up longer

addresses a checkmark in #119 

Solution
========
1. made a 'moreInfo' in the content to render the definition 
2. Made a few changes to the conditional rendering, it's still a little hardcoded, but since designs are still in flux i'm waiting to create something that will work with the final version of the content setup. 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. bun dev
2. option control 1 
3. go to page 7 to see new content 

Screenshots (optional):
-----------------------
<img width="1063" alt="Screenshot 2024-10-08 at 10 41 27 PM" src="https://github.com/user-attachments/assets/6202f141-18ee-493c-91e8-9565f2a70664">
<img width="437" alt="Screenshot 2024-10-08 at 10 42 11 PM" src="https://github.com/user-attachments/assets/fd450cb4-be13-4f2b-9743-af7e3e2ddb0a">
