### PR TITLE
shouldn't show in bonus material

### DIFF
--- a/src/components/ViewSwitch.tsx
+++ b/src/components/ViewSwitch.tsx
@@ -55,7 +55,7 @@ const ViewSwitch: React.FC = () => {
 
     return (
         <div style={{ position: "relative", height: "100%" }}>
-            <VisibilityControl excludedPages={[9, 10, 11]}>
+            <VisibilityControl notInBonusMaterial>
                 <ProgressionControl onPage={1}>
                     <OverlayButton
                         onClick={switchView}


### PR DESCRIPTION
Problem
=======
Estimated review size: xsmall


the view switch shouldn't be visible in the final few screens 

Solution
========
used the newly added `not in bonus material` that is less hardcoded 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. bun dev
2. got to site, push "switch to molecular view"
3. control option 1
4. go to page 8
5. shouldn't see switch button 

Screenshots (optional):
-----------------------
![Uploading Screenshot 2024-10-11 at 10.52.07 AM.png…]()

