### PR TITLE
Feature/hint text 3d viewer

### DIFF
--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -109,7 +109,12 @@ export default function Viewer({ handleTimeChange }: ViewerProps): ReactNode {
         return null;
     }
 
-    const hintOverlay = <>Play, scroll or click + drag to interact</>;
+    const hintOverlay = (
+        <div className={styles.hintOverlay}>
+            Play, scroll or click + drag to interact
+        </div>
+    );
+
     const showHintOverlay =
         !userHasInteracted && trajectoryName !== LIVE_SIMULATION_NAME;
     return (
@@ -120,9 +125,7 @@ export default function Viewer({ handleTimeChange }: ViewerProps): ReactNode {
             key="viewer"
             ref={container}
         >
-            {showHintOverlay && (
-                <div className={styles.hintOverlay}>{hintOverlay}</div>
-            )}
+            {showHintOverlay && hintOverlay}
             <SimulariumViewer
                 lockedCamera={trajectoryName === LIVE_SIMULATION_NAME}
                 disableCache={trajectoryName === LIVE_SIMULATION_NAME}

--- a/src/components/Viewer.tsx
+++ b/src/components/Viewer.tsx
@@ -78,7 +78,6 @@ export default function Viewer({ handleTimeChange }: ViewerProps): ReactNode {
     }, [page, setViewportToContainerSize, heightResized, is3DTrajectory]);
 
     useEffect(() => {
-        console.log("is3DTrajectory", is3DTrajectory);
         if (!is3DTrajectory) {
             return;
         }

--- a/src/components/viewer.module.css
+++ b/src/components/viewer.module.css
@@ -8,3 +8,18 @@
 .container.example {
     height: calc(100vh - var(--nav-bar-height) - var(--content-height));
 }
+
+.container .hint-overlay {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    text-align: center;
+    padding: 16px 24px;
+    border: 1px solid var(--primary-color);
+    border-radius: 4px;
+    color: var(--primary-color);
+    background-color: rgba(0, 0, 0, 0.5);
+    margin-top: 10px;
+    z-index: var(--viewer-overlay-layer);
+}


### PR DESCRIPTION
Problem
=======
Estimated review size: small

Users didn't always realize that they could interact with the 3d model since the 2d model is static 

Solution
========
add hint text that disappears once they interact

NOTE: haven't tested this on a tablet yet 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. bun dev
2. click the first button 
3. open the admin ui (option control 1)
4. go to page 11 
5. click "view examples" 
6. you should see the hint text 
7. scroll or move the 3d port, it should disappear 

Screenshots (optional):
-----------------------
design:
<img width="574" alt="Screenshot 2024-10-31 at 11 38 11 AM" src="https://github.com/user-attachments/assets/bfacd791-e7dd-4fb1-878f-d2d0afd7a8d8">

this branch: 
<img width="638" alt="Screenshot 2024-10-31 at 11 31 11 AM" src="https://github.com/user-attachments/assets/40c0be68-aae6-41c8-b7fd-fb1e7cd70393">
