### PR TITLE
use module in vis and progression

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -558,6 +558,7 @@ function App() {
                         simulariumController,
                         handleTimeChange,
                         page,
+                        module: currentModule,
                         setPage,
                         timeFactor,
                         timeUnit: simulationData.timeUnit,

--- a/src/components/LabView.tsx
+++ b/src/components/LabView.tsx
@@ -7,6 +7,7 @@ import styles from "./labview.module.css";
 import classNames from "classnames";
 import ScaleBar from "./ScaleBar";
 import VisibilityControl from "./shared/VisibilityControl";
+import { Module } from "../types";
 
 const LabView: React.FC = () => {
     const { currentProductionConcentration, maxConcentration, page } =
@@ -24,7 +25,7 @@ const LabView: React.FC = () => {
                 { [styles.top]: page === 1 },
             ])}
         >
-            <VisibilityControl excludedPages={[1]}>
+            <VisibilityControl excludedPages={{ [Module.A_B_AB]: [1] }}>
                 <ScaleBar />
             </VisibilityControl>
             <div className={styles.cuvette}>

--- a/src/components/PlayButton.tsx
+++ b/src/components/PlayButton.tsx
@@ -22,7 +22,6 @@ const PlayButton: React.FC = () => {
                 onPage={{
                     [Module.A_B_AB]: [2, 6],
                     [Module.A_C_AC]: [],
-                    [Module.A_B_C_AB_AC]: [],
                 }}
             >
                 <OverlayButton

--- a/src/components/PlayButton.tsx
+++ b/src/components/PlayButton.tsx
@@ -5,6 +5,7 @@ import { SimulariumContext } from "../simulation/context";
 import ProgressionControl from "./shared/ProgressionControl";
 import VisibilityControl from "./shared/VisibilityControl";
 import { OverlayButton } from "./shared/ButtonLibrary";
+import { Module } from "../types";
 
 const PlayButton: React.FC = () => {
     const { isPlaying, setIsPlaying } = useContext(SimulariumContext);
@@ -16,8 +17,14 @@ const PlayButton: React.FC = () => {
     const iconStyle = { fontSize: 26 };
 
     return (
-        <VisibilityControl excludedPages={[1]}>
-            <ProgressionControl onPage={[2, 6]}>
+        <VisibilityControl excludedPages={{ [Module.A_B_AB]: [1] }}>
+            <ProgressionControl
+                onPage={{
+                    [Module.A_B_AB]: [2, 6],
+                    [Module.A_C_AC]: [],
+                    [Module.A_B_C_AB_AC]: [],
+                }}
+            >
                 <OverlayButton
                     onClick={handleClick}
                     style={{ top: 14, left: 16 }}

--- a/src/components/RecordEquilibriumButton.tsx
+++ b/src/components/RecordEquilibriumButton.tsx
@@ -15,7 +15,6 @@ const RecordEquilibriumButton = ({
             onPage={{
                 [Module.A_B_AB]: [FIRST_RECORD_PAGE, SECOND_RECORD_PAGE],
                 [Module.A_C_AC]: [1],
-                [Module.A_B_C_AB_AC]: [],
             }}
         >
             <PillButton onClick={handleRecordEquilibrium}>Record</PillButton>

--- a/src/components/RecordEquilibriumButton.tsx
+++ b/src/components/RecordEquilibriumButton.tsx
@@ -1,3 +1,4 @@
+import { Module } from "../types";
 import { PillButton } from "./shared/ButtonLibrary";
 import ProgressionControl from "./shared/ProgressionControl";
 
@@ -10,7 +11,13 @@ const RecordEquilibriumButton = ({
     handleRecordEquilibrium,
 }: RecordEquilibriumButtonProps) => {
     return (
-        <ProgressionControl onPage={[FIRST_RECORD_PAGE, SECOND_RECORD_PAGE]}>
+        <ProgressionControl
+            onPage={{
+                [Module.A_B_AB]: [FIRST_RECORD_PAGE, SECOND_RECORD_PAGE],
+                [Module.A_C_AC]: [1],
+                [Module.A_B_C_AB_AC]: [],
+            }}
+        >
             <PillButton onClick={handleRecordEquilibrium}>Record</PillButton>
         </ProgressionControl>
     );

--- a/src/components/ViewSwitch.tsx
+++ b/src/components/ViewSwitch.tsx
@@ -10,6 +10,7 @@ import Molecules from "./icons/Molecules";
 import LabView from "./LabView";
 import usePageNumber from "../hooks/usePageNumber";
 import VisibilityControl from "./shared/VisibilityControl";
+import { Module } from "../types";
 
 enum View {
     Lab = "lab",
@@ -56,7 +57,7 @@ const ViewSwitch: React.FC = () => {
     return (
         <div style={{ position: "relative", height: "100%" }}>
             <VisibilityControl notInBonusMaterial>
-                <ProgressionControl onPage={[1, 3, 4]}>
+                <ProgressionControl onPage={{ [Module.A_B_AB]: [1, 3, 4] }}>
                     <OverlayButton
                         onClick={switchView}
                         style={buttonStyle}

--- a/src/components/main-layout/LeftPanel.tsx
+++ b/src/components/main-layout/LeftPanel.tsx
@@ -4,6 +4,7 @@ import {
     AgentName,
     CurrentConcentration,
     InputConcentration,
+    Module,
 } from "../../types";
 import VisibilityControl from "../shared/VisibilityControl";
 import EventsOverTimePlot from "../plots/EventsOverTimePlot";
@@ -28,9 +29,20 @@ const LeftPanel: React.FC<LeftPanelProps> = ({
     unbindingEventsOverTime,
     adjustableAgent,
 }) => {
+    const concentrationExcludedPages = {
+        [Module.A_B_AB]: [0, 1],
+        [Module.A_C_AC]: [],
+        [Module.A_B_C_AB_AC]: [],
+    };
+
+    const eventsOverTimeExcludedPages = {
+        [Module.A_B_AB]: [0, 1, 2],
+        [Module.A_C_AC]: [],
+        [Module.A_B_C_AB_AC]: [],
+    };
     return (
         <>
-            <VisibilityControl excludedPages={[0, 1]}>
+            <VisibilityControl excludedPages={concentrationExcludedPages}>
                 <Concentration
                     concentration={inputConcentration}
                     liveConcentration={liveConcentration}
@@ -39,7 +51,10 @@ const LeftPanel: React.FC<LeftPanelProps> = ({
                     adjustableAgent={adjustableAgent}
                 />
             </VisibilityControl>
-            <VisibilityControl excludedPages={[0, 1, 2]} notInBonusMaterial>
+            <VisibilityControl
+                excludedPages={eventsOverTimeExcludedPages}
+                notInBonusMaterial
+            >
                 <EventsOverTimePlot
                     bindingEventsOverTime={bindingEventsOverTime}
                     unbindingEventsOverTime={unbindingEventsOverTime}

--- a/src/components/shared/ProgressionControl.tsx
+++ b/src/components/shared/ProgressionControl.tsx
@@ -11,7 +11,7 @@ type ProgressionControlChildProps =
 type ProgressionControlChild = React.ReactElement<ProgressionControlChildProps>;
 interface ProgressionControlProps {
     children: ProgressionControlChild;
-    onPage: { [key in Module]?: number | number[] };
+    onPage: { [key in Module]?: number[] };
 }
 
 /**
@@ -26,13 +26,10 @@ const ProgressionControl: React.FC<ProgressionControlProps> = ({
     const { page, setPage, module } = useContext(SimulariumContext);
     const pagesToAdvance = onPage[module];
     const progress = () => {
-        if (Array.isArray(pagesToAdvance)) {
-            if (pagesToAdvance.includes(page)) {
+        if (pagesToAdvance.includes(page)) {
                 setPage(page + 1);
             }
-        } else if (page === pagesToAdvance) {
-            setPage(page + 1);
-        }
+        } 
     };
 
     const mergeHandlers = (baseHandler: BaseHandler) => {

--- a/src/components/shared/ProgressionControl.tsx
+++ b/src/components/shared/ProgressionControl.tsx
@@ -26,7 +26,7 @@ const ProgressionControl: React.FC<ProgressionControlProps> = ({
     const { page, setPage, module } = useContext(SimulariumContext);
     const pagesToAdvance = onPage[module];
     const progress = () => {
-        if (pagesToAdvance.includes(page)) {
+        if (pagesToAdvance?.includes(page)) {
             setPage(page + 1);
         }
     };

--- a/src/components/shared/ProgressionControl.tsx
+++ b/src/components/shared/ProgressionControl.tsx
@@ -25,9 +25,13 @@ const ProgressionControl: React.FC<ProgressionControlProps> = ({
 }) => {
     const { page, setPage, module } = useContext(SimulariumContext);
     const pagesToAdvance = onPage[module];
+    let showHighlight = false;
     const progress = () => {
         if (pagesToAdvance?.includes(page)) {
             setPage(page + 1);
+            showHighlight = true;
+        } else {
+            showHighlight = false;
         }
     };
 
@@ -46,10 +50,6 @@ const ProgressionControl: React.FC<ProgressionControlProps> = ({
             }
         };
     };
-
-    const showHighlight =
-        (Array.isArray(onPage) && onPage[0] === page) ||
-        page === pagesToAdvance;
 
     const className = showHighlight ? styles.hintHighlight : "";
 

--- a/src/components/shared/ProgressionControl.tsx
+++ b/src/components/shared/ProgressionControl.tsx
@@ -27,9 +27,8 @@ const ProgressionControl: React.FC<ProgressionControlProps> = ({
     const pagesToAdvance = onPage[module];
     const progress = () => {
         if (pagesToAdvance.includes(page)) {
-                setPage(page + 1);
-            }
-        } 
+            setPage(page + 1);
+        }
     };
 
     const mergeHandlers = (baseHandler: BaseHandler) => {

--- a/src/components/shared/ProgressionControl.tsx
+++ b/src/components/shared/ProgressionControl.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { SimulariumContext } from "../../simulation/context";
-import { BaseHandler, ProgressionControlEvent } from "../../types";
+import { BaseHandler, Module, ProgressionControlEvent } from "../../types";
 
 import styles from "./progression-control.module.css";
 
@@ -11,7 +11,7 @@ type ProgressionControlChildProps =
 type ProgressionControlChild = React.ReactElement<ProgressionControlChildProps>;
 interface ProgressionControlProps {
     children: ProgressionControlChild;
-    onPage: number | number[];
+    onPage: { [key in Module]?: number | number[] };
 }
 
 /**
@@ -23,14 +23,14 @@ const ProgressionControl: React.FC<ProgressionControlProps> = ({
     children,
     onPage,
 }) => {
-    const { page, setPage } = useContext(SimulariumContext);
-
+    const { page, setPage, module } = useContext(SimulariumContext);
+    const pagesToAdvance = onPage[module];
     const progress = () => {
-        if (Array.isArray(onPage)) {
-            if (onPage.includes(page)) {
+        if (Array.isArray(pagesToAdvance)) {
+            if (pagesToAdvance.includes(page)) {
                 setPage(page + 1);
             }
-        } else if (page === onPage) {
+        } else if (page === pagesToAdvance) {
             setPage(page + 1);
         }
     };
@@ -52,7 +52,8 @@ const ProgressionControl: React.FC<ProgressionControlProps> = ({
     };
 
     const showHighlight =
-        (Array.isArray(onPage) && onPage[0] === page) || page === onPage;
+        (Array.isArray(onPage) && onPage[0] === page) ||
+        page === pagesToAdvance;
 
     const className = showHighlight ? styles.hintHighlight : "";
 

--- a/src/components/shared/VisibilityControl.tsx
+++ b/src/components/shared/VisibilityControl.tsx
@@ -1,12 +1,12 @@
 import React, { useContext } from "react";
 import { SimulariumContext } from "../../simulation/context";
-import { Section } from "../../types";
+import { Module, Section } from "../../types";
 
 interface VisibilityControlProps {
     children: React.ReactNode;
     startPage?: number;
-    excludedPages?: number[];
-    includedPages?: number[];
+    excludedPages?: { [key in Module]?: number[] };
+    includedPages?: { [key in Module]?: number[] };
     conditionalRender?: boolean;
     notInBonusMaterial?: boolean;
     notInIntroduction?: boolean;
@@ -21,7 +21,7 @@ const VisibilityControl: React.FC<VisibilityControlProps> = ({
     notInIntroduction,
     startPage,
 }) => {
-    const { page, section } = useContext(SimulariumContext);
+    const { page, section, module } = useContext(SimulariumContext);
     if (conditionalRender === false) {
         return null;
     }
@@ -29,9 +29,9 @@ const VisibilityControl: React.FC<VisibilityControlProps> = ({
     let shouldRender = true;
 
     if (includedPages) {
-        shouldRender = includedPages.includes(page);
+        shouldRender = includedPages[module]?.includes(page) ?? false;
     } else if (excludedPages) {
-        shouldRender = !excludedPages.includes(page);
+        shouldRender = !excludedPages[module]?.includes(page);
     }
     if (startPage && page < startPage) {
         shouldRender = false;

--- a/src/simulation/context.tsx
+++ b/src/simulation/context.tsx
@@ -9,12 +9,13 @@ import {
     LIVE_SIMULATION_NAME,
     NANO,
 } from "../constants";
-import { AgentName, ProductName, Section } from "../types";
+import { AgentName, Module, ProductName, Section } from "../types";
 
 interface SimulariumContextType {
     trajectoryName: string;
     productName: ProductName;
     maxConcentration: number;
+    module: Module;
     getAgentColor: (agentName: AgentName) => string;
     currentProductionConcentration: number;
     isPlaying: boolean;
@@ -36,6 +37,7 @@ interface SimulariumContextType {
 export const SimulariumContext = createContext({
     trajectoryName: LIVE_SIMULATION_NAME,
     productName: ProductName.AB,
+    module: Module.A_B_AB,
     maxConcentration: 10,
     getAgentColor: () => "",
     currentProductionConcentration: 0,


### PR DESCRIPTION
Problem
=======
Estimated review size: small
closes #179 

In getting ready for developing the second module, page progression and visibility need to be controlled by both page number and the current module 

Solution
========
I grouped the arrays into a per module mapping. this doesn't break any of the current functionality 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)



Steps to Verify:
----------------
1. bun dev
2. the app should progress normally 

