### PR TITLE
move equ check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,11 @@
-import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import {
+    ReactNode,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import {
     SimulariumController,
     TimeData,
@@ -41,6 +48,7 @@ import {
     getColorIndex,
     indexToTime,
     insertValueSorted,
+    isSlopeZero,
     updateArrayInState,
 } from "./utils";
 import PreComputedPlotData from "./simulation/PreComputedPlotData";
@@ -146,6 +154,20 @@ function App() {
         setTimeToReachEquilibrium([]);
         setDataColors([]);
     }, []);
+
+    const isPassedEquilibrium = useRef(false);
+    const arrayLength = currentProductConcentrationArray.length;
+    if (
+        !isPassedEquilibrium.current &&
+        arrayLength > 0 &&
+        arrayLength % 50 === 0
+    ) {
+        isPassedEquilibrium.current = isSlopeZero(
+            currentProductConcentrationArray
+        );
+    } else if (arrayLength === 0 && isPassedEquilibrium.current) {
+        isPassedEquilibrium.current = false;
+    }
 
     // SIMULATION INITIALIZATION
     const simulariumController = useMemo(() => {
@@ -523,7 +545,7 @@ function App() {
             return false;
         }
 
-        if (!clientSimulator.isMixed()) {
+        if (!isPassedEquilibrium.current) {
             setEquilibriumFeedbackTimeout("Not yet!");
             return false;
         }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -44,3 +44,18 @@ export const indexToTime = (
         return index * timeFactor;
     }
 };
+
+export const isSlopeZero = (array: number[]) => {
+    const sliceSize = 25;
+    const averageOfLastFive =
+        array.slice(-sliceSize).reduce((a, b) => a + b) / sliceSize;
+    const averageOfFirstFive =
+        array.slice(-sliceSize * 2, -sliceSize).reduce((a, b) => a + b) /
+        sliceSize;
+    const slope = averageOfLastFive - averageOfFirstFive;
+    if (Math.abs(slope) < 0.01) {
+        return true;
+    } else {
+        return false;
+    }
+};


### PR DESCRIPTION
Problem
=======
Estimated review size: md

With the new module, the previous mix check wasn't working very well. The reaction reached equilibrium before the agents are well mixed. 

Solution
========
Change from a count on each side check to a slope check that averages over the last 50 values. 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)



Steps to Verify:
----------------
1. bun dev
2. got to page 5, record equilibrium 
3. go to module 2 
4. record equilibrium 


