### PR TITLE
cap the step count

### DIFF
--- a/src/components/concentration-display/LiveConcentrationDisplay.tsx
+++ b/src/components/concentration-display/LiveConcentrationDisplay.tsx
@@ -18,8 +18,10 @@ const LiveConcentrationDisplay: React.FC<LiveConcentrationDisplayProps> = ({
 }) => {
     const { maxConcentration, getAgentColor } = useContext(SimulariumContext);
     // the steps have a 2px gap, so we are adjusting the
-    // size of the step based on the total number we want
-    const steps = maxConcentration;
+    // size of the step based on the total number we want.
+    // cap steps so each step is at least 4px wide (2px step + 2px gap)
+    const maxSteps = Math.floor(width / 4);
+    const steps = Math.min(maxConcentration, Math.max(1, maxSteps));
     const size = width / steps - 2;
     return (
         <div className={styles.container}>


### PR DESCRIPTION
Problem
=======
Estimated review size: small

closes #210 

Solution
========
capped the step size of the bar with @claude 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. bun dev 
3. go to page 16 (open admin panel by clicking control+option+1)
4. check bar

Screenshots (optional):
-----------------------
before
<img width="2166" height="620" alt="Screenshot 2026-05-26 at 3 08 00 PM" src="https://github.com/user-attachments/assets/61470f34-b3de-4ab2-8209-5cc6bee7e0d2" />

<img width="646" height="694" alt="Screenshot 2026-05-28 at 12 56 20 PM" src="https://github.com/user-attachments/assets/4e682ca7-acf9-4f1e-a158-f4bc39c85a14" />
